### PR TITLE
ANDing describe_snapshots API filter

### DIFF
--- a/serverless-janitor-ebs-snapshots.py
+++ b/serverless-janitor-ebs-snapshots.py
@@ -1,4 +1,5 @@
 import boto3
+from botocore.exceptions import ClientError
 import datetime
 
 # Set the global variables
@@ -42,12 +43,17 @@ def janitor_for_snapshots():
     snapsDeleted = {'Snapshots': []}
 
     for snap in snaps_to_remove['Snapshots']:
-        ec2_client.delete_snapshot(SnapshotId=snap['SnapshotId'])
-        snapsDeleted['Snapshots'].append({'Description': snap['Description'], 'SnapshotId': snap['SnapshotId'], 'OwnerId': snap['OwnerId']})
+        try:
+            ec2_client.delete_snapshot(SnapshotId=snap['SnapshotId'])
+            snapsDeleted['Snapshots'].append({'Description': snap['Description'], 'SnapshotId': snap['SnapshotId'], 'OwnerId': snap['OwnerId']})
+        except ClientError as e:
+            if "is currently in use by" in str(e):
+                print("Snapshot {} is part of an AMI".format(snap.get('SnapshotId')))
 
     snapsDeleted['Status']='{} Snapshots were Deleted'.format( len(snaps_to_remove['Snapshots']))
 
     return snapsDeleted
+
 def lambda_handler(event, context):
     return janitor_for_snapshots()
 

--- a/serverless-janitor-ebs-snapshots.py
+++ b/serverless-janitor-ebs-snapshots.py
@@ -25,9 +25,10 @@ def janitor_for_snapshots():
 
     snap_older_than_RetentionDays = ( datetime.date.today() - datetime.timedelta(days= int(globalVars['RetentionDays'])) ).strftime('%Y-%m-%d')
     delete_today = datetime.date.today().strftime('%Y-%m-%d')
+
+    tag_key = 'tag:' + globalVars['findNeedle']
     filters = [
-        {'Name': 'tag-key', 'Values': [globalVars['findNeedle']]},
-        {'Name': 'tag-value', 'Values': [delete_today]},
+        {'Name': tag_key, 'Values': [delete_today]},
     ]
     # Get list of Snaps with Tag 'globalVars['findNeedle']'
     snaps_to_remove = ec2_client.describe_snapshots(OwnerIds=account_ids,Filters=filters)


### PR DESCRIPTION
As per boto3 documentation (http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_snapshots)

tag-key and tag-value in a filter will return all resources with either tag-key KEY OR tag-key VALUE. but in order to return only resources with both tag KEY AND VALUE, tag:key should be used instead.